### PR TITLE
Continous learning

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,15 @@ wgbm_model.fit(X, y, init_model="ckpt_100.pkl")
 print('WarpGBN number of trees: ', wgbm_model.n_estimators)
 ```
 
+**Continuous learning output:**
+
+```
+Finished training forest.
+Saved WarpGBM checkpoint to ckpt_100.pkl
+Loaded checkpoint into current WarpGBM instance from ckpt_100.pkl. Already 100 trees, will grow additional 100 trees.
+Finished training forest.
+WarpGBN number of trees:  200
+```
 ---
 
 ### Pre-binned Data Example (Numerai)

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ If your data evolves over time, WarpGBM is the only GBDT library designed to *ad
 - Supports **pre-binned data** or **automatic quantile binning**
 - Works with `float32` or `int8` inputs
 - Built-in **validation and early stopping** support with MSE, RMSLE, or correlation metrics
+- Supports continous learning
 - Simple install with `pip`, no custom drivers required
 
 > 💡 **Note:** WarpGBM v1.0.0 is a *generalization* of the traditional GBDT algorithm.
@@ -195,6 +196,32 @@ print(f"WarpGBM:     corr = {np.corrcoef(wgbm_preds, y)[0,1]:.4f}, time = {wgbm_
 LightGBM:   corr = 0.8742, time = 37.33s
 WarpGBM:     corr = 0.8621, time = 5.40s
 ```
+
+---
+
+### Continous learning
+
+```python
+import numpy as np
+from sklearn.datasets import make_regression
+from warpgbm import WarpGBM
+
+# Create synthetic regression dataset
+X, y = make_regression(n_samples=100_000, n_features=500, noise=0.1, random_state=42)
+X = X.astype(np.float32)
+y = y.astype(np.float32)
+
+# Train WarpGBM inital model
+wgbm_model = WarpGBM(max_depth=5, n_estimators=100, learning_rate=0.01, num_bins=7)
+wgbm_model.fit(X, y)
+wgbm_model.save_model("ckpt_100.pkl")
+
+# Continue training of WarpGBM inital model
+wgbm_model = WarpGBM(n_estimators=100)
+wgbm_model.fit(X, y, init_model="ckpt_100.pkl")
+
+# Results
+print('WarpGBN number of trees: ', wgbm_model.n_estimators)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -201,6 +201,13 @@ WarpGBM:     corr = 0.8621, time = 5.40s
 
 ### Continous learning
 
+WarpGBM supports continuous (incremental) learning, allowing you to extend training from a previously saved model checkpoint instead of starting from scratch.
+This makes it possible to:
+- Train in stages without retraining the entire model
+- Adapt an existing model as new data becomes available
+- Reduce training time by reusing previously learned trees
+You can save a trained model with `.save_model()` and later resume training by passing its path to the `init_model` parameter in `.fit()`.
+
 ```python
 import numpy as np
 from sklearn.datasets import make_regression

--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ wgbm_model.fit(X, y, init_model="ckpt_100.pkl")
 
 # Results
 print('WarpGBN number of trees: ', wgbm_model.n_estimators)
+```
 
 ---
 

--- a/warpgbm/core.py
+++ b/warpgbm/core.py
@@ -8,6 +8,8 @@ from tqdm import tqdm
 from typing import Tuple
 from torch import Tensor
 import gc
+import joblib
+import os
 
 
 class WarpGBM(BaseEstimator, RegressorMixin):
@@ -192,7 +194,7 @@ class WarpGBM(BaseEstimator, RegressorMixin):
         else:
             self.bin_edges = None
 
-        print(f"Loaded checkpoint into current WarpGBM instance from {path}. Already {loaded_len} trees, will grow additional {self.n_estimators - loaded_len}).")
+        print(f"Loaded checkpoint into current WarpGBM instance from {path}. Already {loaded_len} trees, will grow additional {self.n_estimators - loaded_len) trees.")
 
     def validate_fit_params(
         self, X, y, era_id, X_eval, y_eval, eval_every_n_trees, early_stopping_rounds, eval_metric

--- a/warpgbm/core.py
+++ b/warpgbm/core.py
@@ -194,7 +194,7 @@ class WarpGBM(BaseEstimator, RegressorMixin):
         else:
             self.bin_edges = None
 
-        print(f"Loaded checkpoint into current WarpGBM instance from {path}. Already {loaded_len} trees, will grow additional {self.n_estimators - loaded_len) trees.")
+        print(f"Loaded checkpoint into current WarpGBM instance from {path}. Already {loaded_len} trees, will grow additional {self.n_estimators - loaded_len} trees.")
 
     def validate_fit_params(
         self, X, y, era_id, X_eval, y_eval, eval_every_n_trees, early_stopping_rounds, eval_metric


### PR DESCRIPTION
This PR provides WarpGBM's checkpointing / resume behavior to support continuous learning:

When fit(..., init_model=path) is used, the saved checkpoint is loaded and the model will append the requested number of new trees to the loaded forest (of course other parameters also could be modified).

E.g. calling WarpGBM(n_estimators=200).fit(..., init_model="ckpt_100.pkl") where ckpt_100.pkl contains 100 trees will result in a final model with 300 trees (100 loaded + 200 new). I've added example in readme.

Two addtional methods are added:
- save_model
- load_state (for internal use)

Backward-compatibility: when init_model is not used, behavior is unchanged.

Please review this PR when you have time. Any comments on code clarity, or potential edge cases would be very welcome.